### PR TITLE
Fix Python driver package

### DIFF
--- a/code/python/example.py
+++ b/code/python/example.py
@@ -1,4 +1,4 @@
-# pip3 install neo4j-driver
+# pip3 install neo4j
 # python3 example.py
 
 from neo4j import GraphDatabase, basic_auth


### PR DESCRIPTION
If we can't agree on the rest 
(https://github.com/neo4j-graph-examples/template/pull/31), let's at least fix this. The mentioned package name was meant to be removed since 2.0 it's just that no one took the time to deprecate it. Don't make our users' lives harder by guiding more of them towards the package that will maybe be deprecated in the near future.